### PR TITLE
Align heading hash at the top of the heading

### DIFF
--- a/lib/mdx/compile.ts
+++ b/lib/mdx/compile.ts
@@ -30,7 +30,7 @@ const getRahOptions = (): Partial<rahOptions> => ({
 	behavior: "append",
 	content: { type: "text", value: "#" },
 	properties: {
-		class: "text-gray-500 absolute right-full mr-3",
+		class: "text-gray-500 absolute right-full top-0 mr-3",
 	},
 });
 


### PR DESCRIPTION
Heading hashes are now aligned at the top of the long heading.
![image](https://user-images.githubusercontent.com/12984316/157389125-1494f103-6a22-4893-a3ba-4dbcd5d5783b.png)
