### PR TITLE
fix: remove typo in config's type.ts's comments

### DIFF
--- a/lib/blog/config/type.ts
+++ b/lib/blog/config/type.ts
@@ -39,7 +39,7 @@ export interface BlogConfig {
 	dateFormat?: BlogConfigDate;
 	/**
 	 * Whether to render a README content when a folder has one. This can be
-	 * used to hide the folder's file list. See the type definition aboe for
+	 * used to hide the folder's file list. See the type definition above for
 	 * detail.
 	 */
 	readme?: BlogConfigReadonly;


### PR DESCRIPTION
Hello, I was reading the config format and noticed there's a small typo.