### PR TITLE
Parse guest domain host, refuse platform names

### DIFF
--- a/src/domain/host.ts
+++ b/src/domain/host.ts
@@ -1,11 +1,8 @@
 import { hasPlatform } from "./platform";
 
-const LABEL = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
-const IPV4 = /^(?:\d{1,3}\.){3}\d{1,3}$/;
-
 /**
  * Parse a guest-entered domain into a hostname we can claim.
- * Null if empty, invalid, or one of ours.
+ * Null if empty, unparsable, or one of ours.
  */
 export function parseDomainHost(input: string): string | null {
   const trimmed = input.trim().toLowerCase();
@@ -13,22 +10,11 @@ export function parseDomainHost(input: string): string | null {
 
   const withScheme = trimmed.includes("://") ? trimmed : `https://${trimmed}`;
 
-  let hostname: string;
   try {
-    hostname = new URL(withScheme).hostname;
+    const hostname = new URL(withScheme).hostname;
+    if (hasPlatform(hostname)) return null;
+    return hostname;
   } catch {
     return null;
   }
-
-  if (hostname.endsWith(".")) hostname = hostname.slice(0, -1);
-  if (!isHostname(hostname)) return null;
-  if (hasPlatform(hostname)) return null;
-  return hostname;
-}
-
-function isHostname(value: string): boolean {
-  if (IPV4.test(value)) return false;
-  const labels = value.split(".");
-  if (labels.length < 2) return false;
-  return labels.every((label) => LABEL.test(label));
 }

--- a/src/domain/host.ts
+++ b/src/domain/host.ts
@@ -1,0 +1,34 @@
+import { hasPlatform } from "./platform";
+
+const LABEL = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+const IPV4 = /^(?:\d{1,3}\.){3}\d{1,3}$/;
+
+/**
+ * Parse a guest-entered domain into a hostname we can claim.
+ * Null if empty, invalid, or one of ours.
+ */
+export function parseDomainHost(input: string): string | null {
+  const trimmed = input.trim().toLowerCase();
+  if (trimmed === "") return null;
+
+  const withScheme = trimmed.includes("://") ? trimmed : `https://${trimmed}`;
+
+  let hostname: string;
+  try {
+    hostname = new URL(withScheme).hostname;
+  } catch {
+    return null;
+  }
+
+  if (hostname.endsWith(".")) hostname = hostname.slice(0, -1);
+  if (!isHostname(hostname)) return null;
+  if (hasPlatform(hostname)) return null;
+  return hostname;
+}
+
+function isHostname(value: string): boolean {
+  if (IPV4.test(value)) return false;
+  const labels = value.split(".");
+  if (labels.length < 2) return false;
+  return labels.every((label) => LABEL.test(label));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Increment 1 of self-serve custom domains: parse a guest-entered string into a hostname we can later claim.

`parseDomainHost` trims, lowercases, and accepts a bare host or a pasted URL. It returns null if `URL` throws, or if the host is ours (`memos.pub`, `localhost`, and their subdomains). No extra shape checks — junk IPs and odd names are left to Vercel.

Only for the landing-page input (and the POST that reads it). Request routing keeps using the Host header.

Not wired to the landing page yet.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31af7630-9e2c-4474-af7b-c409a4870438?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31af7630-9e2c-4474-af7b-c409a4870438&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

