### PR TITLE
Lowercase host; pipe clean and custom reasons

### DIFF
--- a/src/domain/custom.ts
+++ b/src/domain/custom.ts
@@ -22,15 +22,22 @@ function isSafeTarget(target: string): boolean {
   return target.split("/").every((s) => s !== "" && s !== "." && s !== "..");
 }
 
+export type DomainCustomReason = "missing" | "unsafe";
+
+type Result =
+  | { ok: true; target: string }
+  | { ok: false; reason: DomainCustomReason };
+
 /**
  * Get blog path from a custom domain.
  * This could be as long as they want.
  * e.g., "thien.do" to "thien-do/blog/notes",
  * which is the same as "thien-do.memos.pub/blog/notes".
  */
-export async function getDomainCustom(domain: string): Promise<string | null> {
+export async function getDomainCustom(domain: string): Promise<Result> {
   const records = await resolveTxtSafe(domain);
   const value = records?.at(0)?.join("") ?? null;
-  if (value === null || !isSafeTarget(value)) return null;
-  return value;
+  if (value === null) return { ok: false, reason: "missing" };
+  if (!isSafeTarget(value)) return { ok: false, reason: "unsafe" };
+  return { ok: true, target: value };
 }

--- a/src/domain/route.ts
+++ b/src/domain/route.ts
@@ -18,9 +18,13 @@ export async function routeDomain(params: {
 
   // Each path returns a target that is safe to splice, or null.
   // A separate platform check saves cost in resolving custom domain.
-  const target = hasPlatform(domain)
-    ? getDomainPlatform(domain)
-    : await getDomainCustom(domain);
+  let target: string | null;
+  if (hasPlatform(domain)) {
+    target = getDomainPlatform(domain);
+  } else {
+    const custom = await getDomainCustom(domain);
+    target = custom.ok ? custom.target : null;
+  }
 
   if (target !== null) {
     return { kind: "rewrite", path: `/blog/${target}${pathname}` };

--- a/src/home/add.ts
+++ b/src/home/add.ts
@@ -2,9 +2,11 @@ import { addVercelDomain } from "@/vercel/add";
 import { listVercelDomains } from "@/vercel/list";
 import { VercelVerify } from "@/vercel/verify";
 
+export type HomeAddReason = "apex-limit";
+
 type Result =
   | { ok: true; verify: VercelVerify }
-  | { ok: false; reason: "apex-limit" };
+  | { ok: false; reason: HomeAddReason };
 
 export async function addHomeDomain(domain: string): Promise<Result> {
   const exists = await listVercelDomains();

--- a/src/home/clean.ts
+++ b/src/home/clean.ts
@@ -1,11 +1,17 @@
 import { hasPlatform } from "@/domain/platform";
 
-export function cleanHomeDomain(raw: string): string | null {
+export type HomeCleanReason = "parse" | "platform";
+
+type Result =
+  | { ok: true; domain: string }
+  | { ok: false; reason: HomeCleanReason };
+
+export function cleanHomeDomain(raw: string): Result {
   const trimmed = raw.trim().toLowerCase();
   const withScheme = trimmed.includes("://") ? trimmed : `https://${trimmed}`;
 
   const domain = URL.parse(withScheme)?.hostname ?? null;
-  if (domain === null) return null;
-  if (hasPlatform(domain)) return null;
-  return domain;
+  if (domain === null) return { ok: false, reason: "parse" };
+  if (hasPlatform(domain)) return { ok: false, reason: "platform" };
+  return { ok: true, domain };
 }

--- a/src/home/connect.ts
+++ b/src/home/connect.ts
@@ -1,5 +1,5 @@
-import { getDomainCustom } from "@/domain/custom";
-import { cleanHomeDomain } from "./clean";
+import { DomainCustomReason, getDomainCustom } from "@/domain/custom";
+import { cleanHomeDomain, HomeCleanReason } from "./clean";
 import { VercelVerify, VercelVerifyReason } from "@/vercel/verify";
 import { getVercelDomain } from "@/vercel/get";
 import { getVercelDomainConfig, VercelConfigReason } from "@/vercel/config";
@@ -7,9 +7,9 @@ import { addHomeDomain } from "./add";
 
 type Result =
   | { type: "success" }
-  | { type: "custom" }
+  | { type: "custom"; reason: DomainCustomReason }
   | { type: "apex-limit" }
-  | { type: "clean" }
+  | { type: "clean"; reason: HomeCleanReason }
   | { type: "config"; reason: VercelConfigReason }
   | { type: "verify"; reason: VercelVerifyReason };
 
@@ -24,12 +24,13 @@ function pipeVerify(verify: VercelVerify): Result {
 export async function connectHomeDomain(
   input: string,
 ): Promise<ConnectHomeDomainResult> {
-  const domain = cleanHomeDomain(input);
-  if (domain === null) return { type: "clean" };
+  const clean = cleanHomeDomain(input);
+  if (clean.ok === false) return { type: "clean", reason: clean.reason };
+  const { domain } = clean;
 
   // Always check for custom first to avoid adding redundant domains
   const custom = await getDomainCustom(domain);
-  if (custom === null) return { type: "custom" };
+  if (custom.ok === false) return { type: "custom", reason: custom.reason };
 
   // We could add domain at this point, and display verified status,
   // but it's easier to reason by doing things in serial

--- a/src/home/connect.ts
+++ b/src/home/connect.ts
@@ -3,12 +3,12 @@ import { cleanHomeDomain, HomeCleanReason } from "./clean";
 import { VercelVerify, VercelVerifyReason } from "@/vercel/verify";
 import { getVercelDomain } from "@/vercel/get";
 import { getVercelDomainConfig, VercelConfigReason } from "@/vercel/config";
-import { addHomeDomain } from "./add";
+import { addHomeDomain, HomeAddReason } from "./add";
 
 type Result =
   | { type: "success" }
   | { type: "custom"; reason: DomainCustomReason }
-  | { type: "apex-limit" }
+  | { type: "add"; reason: HomeAddReason }
   | { type: "clean"; reason: HomeCleanReason }
   | { type: "config"; reason: VercelConfigReason }
   | { type: "verify"; reason: VercelVerifyReason };
@@ -41,7 +41,9 @@ export async function connectHomeDomain(
 
   if (detail.found === false) {
     const result = await addHomeDomain(domain);
-    return result.ok ? pipeVerify(result.verify) : { type: result.reason };
+    return result.ok
+      ? pipeVerify(result.verify)
+      : { type: "add", reason: result.reason };
   }
 
   return pipeVerify(detail.verify);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,8 +6,8 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   // This is more reliable than nextUrl.hostname,
   // which could be overriden by Vercel, both local and remote.
   const host = request.headers.get("host") ?? "";
-  // Drop port
-  const domain = host.split(":").at(0) ?? "";
+  // Drop port and case. Host is case-insensitive.
+  const domain = host.split(":").at(0)?.toLowerCase() ?? "";
   const { pathname } = request.nextUrl;
   const route = await routeDomain({ domain, pathname });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Host is case-insensitive. `routeDomain` used to lowercase it. That was dropped when the port strip moved to `proxy.ts`. This puts it back.

`clean`, `custom`, and `add` no longer collapse failures into a bare type. Connect pipes their reasons the same way it pipes `config` and `verify`.

- clean: `parse` or `platform`
- custom: `missing` or `unsafe`
- add: `apex-limit`

Route still treats any custom miss as no rewrite.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30594152-021c-4e51-9c0c-6d3c7f9de5de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30594152-021c-4e51-9c0c-6d3c7f9de5de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

