### PR TITLE
Show folder README before the entry list

### DIFF
--- a/src/blog/dir.tsx
+++ b/src/blog/dir.tsx
@@ -1,21 +1,26 @@
 import type { ReactElement } from "react";
 import type { GitContentEntry } from "@/git/content";
+import { BlogFile } from "./file";
 
 export function BlogDir(props: {
   linkBase: string;
   entries: GitContentEntry[];
+  readme: string | null;
 }): ReactElement {
-  const { linkBase, entries } = props;
+  const { linkBase, entries, readme } = props;
 
   return (
-    <ul>
-      {entries.map((entry) => (
-        <li key={entry.path}>
-          <a href={`${linkBase}/${entry.path}`}>
-            {entry.type === "dir" ? `${entry.name}/` : entry.name}
-          </a>
-        </li>
-      ))}
-    </ul>
+    <div>
+      {readme !== null ? <BlogFile text={readme} /> : null}
+      <ul>
+        {entries.map((entry) => (
+          <li key={entry.path}>
+            <a href={`${linkBase}/${entry.path}`}>
+              {entry.type === "dir" ? `${entry.name}/` : entry.name}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }

--- a/src/blog/dir.tsx
+++ b/src/blog/dir.tsx
@@ -1,21 +1,30 @@
 import type { ReactElement } from "react";
 import type { GitContentEntry } from "@/git/content";
+import { BlogFile } from "./file";
 
 export function BlogDir(props: {
   linkBase: string;
   entries: GitContentEntry[];
+  readme: string | null;
 }): ReactElement {
-  const { linkBase, entries } = props;
+  const { linkBase, entries, readme } = props;
+  const listed =
+    readme === null
+      ? entries
+      : entries.filter((entry) => entry.name !== "README.md");
 
   return (
-    <ul>
-      {entries.map((entry) => (
-        <li key={entry.path}>
-          <a href={`${linkBase}/${entry.path}`}>
-            {entry.type === "dir" ? `${entry.name}/` : entry.name}
-          </a>
-        </li>
-      ))}
-    </ul>
+    <div>
+      {readme !== null ? <BlogFile text={readme} /> : null}
+      <ul>
+        {listed.map((entry) => (
+          <li key={entry.path}>
+            <a href={`${linkBase}/${entry.path}`}>
+              {entry.type === "dir" ? `${entry.name}/` : entry.name}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }

--- a/src/blog/dir.tsx
+++ b/src/blog/dir.tsx
@@ -1,30 +1,21 @@
 import type { ReactElement } from "react";
 import type { GitContentEntry } from "@/git/content";
-import { BlogFile } from "./file";
 
 export function BlogDir(props: {
   linkBase: string;
   entries: GitContentEntry[];
-  readme: string | null;
 }): ReactElement {
-  const { linkBase, entries, readme } = props;
-  const listed =
-    readme === null
-      ? entries
-      : entries.filter((entry) => entry.name !== "README.md");
+  const { linkBase, entries } = props;
 
   return (
-    <div>
-      {readme !== null ? <BlogFile text={readme} /> : null}
-      <ul>
-        {listed.map((entry) => (
-          <li key={entry.path}>
-            <a href={`${linkBase}/${entry.path}`}>
-              {entry.type === "dir" ? `${entry.name}/` : entry.name}
-            </a>
-          </li>
-        ))}
-      </ul>
-    </div>
+    <ul>
+      {entries.map((entry) => (
+        <li key={entry.path}>
+          <a href={`${linkBase}/${entry.path}`}>
+            {entry.type === "dir" ? `${entry.name}/` : entry.name}
+          </a>
+        </li>
+      ))}
+    </ul>
   );
 }

--- a/src/blog/dir.tsx
+++ b/src/blog/dir.tsx
@@ -1,13 +1,10 @@
 import type { ReactElement } from "react";
-import type { GitContentEntry } from "@/git/content";
 import { BlogFile } from "./file";
+import type { BlogViewDir } from "./view";
 
-export function BlogDir(props: {
-  linkBase: string;
-  entries: GitContentEntry[];
-  readme: string | null;
-}): ReactElement {
-  const { linkBase, entries, readme } = props;
+export function BlogDir(props: { view: BlogViewDir }): ReactElement {
+  const { view } = props;
+  const { linkBase, entries, readme } = view;
 
   return (
     <div>

--- a/src/blog/page.tsx
+++ b/src/blog/page.tsx
@@ -19,7 +19,11 @@ export async function BlogPage(props: {
       return <BlogFile text={view.text} />;
     case "dir":
       return (
-        <BlogDir linkBase={view.linkBase} entries={view.entries} readme={view.readme} />
+        <BlogDir
+          linkBase={view.linkBase}
+          entries={view.entries}
+          readme={view.readme}
+        />
       );
     case "owner":
       return <BlogOwner repos={view.repos} />;

--- a/src/blog/page.tsx
+++ b/src/blog/page.tsx
@@ -18,13 +18,7 @@ export async function BlogPage(props: {
     case "file":
       return <BlogFile text={view.text} />;
     case "dir":
-      return (
-        <BlogDir
-          linkBase={view.linkBase}
-          entries={view.entries}
-          readme={view.readme}
-        />
-      );
+      return <BlogDir view={view} />;
     case "owner":
       return <BlogOwner repos={view.repos} />;
   }

--- a/src/blog/page.tsx
+++ b/src/blog/page.tsx
@@ -19,11 +19,10 @@ export async function BlogPage(props: {
       return <BlogFile text={view.text} />;
     case "dir":
       return (
-        <BlogDir
-          linkBase={view.linkBase}
-          entries={view.entries}
-          readme={view.readme}
-        />
+        <>
+          {view.readme !== null ? <BlogFile text={view.readme} /> : null}
+          <BlogDir linkBase={view.linkBase} entries={view.entries} />
+        </>
       );
     case "owner":
       return <BlogOwner repos={view.repos} />;

--- a/src/blog/page.tsx
+++ b/src/blog/page.tsx
@@ -19,10 +19,11 @@ export async function BlogPage(props: {
       return <BlogFile text={view.text} />;
     case "dir":
       return (
-        <>
-          {view.readme !== null ? <BlogFile text={view.readme} /> : null}
-          <BlogDir linkBase={view.linkBase} entries={view.entries} />
-        </>
+        <BlogDir
+          linkBase={view.linkBase}
+          entries={view.entries}
+          readme={view.readme}
+        />
       );
     case "owner":
       return <BlogOwner repos={view.repos} />;

--- a/src/blog/page.tsx
+++ b/src/blog/page.tsx
@@ -18,7 +18,9 @@ export async function BlogPage(props: {
     case "file":
       return <BlogFile text={view.text} />;
     case "dir":
-      return <BlogDir linkBase={view.linkBase} entries={view.entries} />;
+      return (
+        <BlogDir linkBase={view.linkBase} entries={view.entries} readme={view.readme} />
+      );
     case "owner":
       return <BlogOwner repos={view.repos} />;
   }

--- a/src/blog/tree.ts
+++ b/src/blog/tree.ts
@@ -1,31 +1,48 @@
-import type { GitContent } from "@/git/content";
+import type { GitContentEntry } from "@/git/content";
 import { getGitContent } from "@/git/content";
+
+export type BlogTree =
+  | { kind: "file"; text: string }
+  | {
+      kind: "dir";
+      entries: GitContentEntry[];
+      readme: string | null;
+    };
 
 /**
  * Get content within a specific repo.
- * Include an auto ".md" suffix fetch.
+ * Include auto ".md" suffix and auto folder README.
  */
 export async function getBlogTree(params: {
   owner: string;
   repo: string;
   segments: string[];
-}): Promise<GitContent | null> {
+}): Promise<BlogTree | null> {
   const { owner, repo, segments } = params;
 
   // Auto ".md" fetch. An empty ".md" at root is wasted 404
   const last = segments.at(-1);
   const mdSegments = [...segments.slice(0, -1), `${last ?? ""}.md`];
+  const readmeSegments = [...segments, "README.md"];
 
-  const [exact, auto] = await Promise.all([
+  const [exact, autoMd, autoReadme] = await Promise.all([
     getGitContent({ owner, repo, segments }),
     getGitContent({ owner, repo, segments: mdSegments }),
+    getGitContent({ owner, repo, segments: readmeSegments }),
   ]);
 
   // The exact "bar" — file or folder — beats the auto "bar.md".
-  if (exact !== null) return exact;
+  if (exact !== null) {
+    if (exact.kind === "file") return exact;
+    return {
+      kind: "dir",
+      entries: exact.entries,
+      readme: autoReadme?.kind === "file" ? autoReadme.text : null,
+    };
+  }
 
   // Only accept auto .md to a file
-  if (auto?.kind === "file") return auto;
+  if (autoMd?.kind === "file") return autoMd;
 
   return null;
 }

--- a/src/blog/view.ts
+++ b/src/blog/view.ts
@@ -6,7 +6,12 @@ import { getBlogTree } from "./tree";
 
 export type BlogView =
   | { kind: "file"; text: string }
-  | { kind: "dir"; entries: GitContentEntry[]; linkBase: string; readme: string | null }
+  | {
+      kind: "dir";
+      entries: GitContentEntry[];
+      linkBase: string;
+      readme: string | null;
+    }
   | { kind: "owner"; repos: GitRepo[] };
 
 async function fromContent(params: {
@@ -25,7 +30,11 @@ async function fromContent(params: {
       const found = content.entries.find((entry) => entry.name === "README.md");
       const file =
         found?.type === "file"
-          ? await getGitContent({ owner, repo, segments: [...segments, "README.md"] })
+          ? await getGitContent({
+              owner,
+              repo,
+              segments: [...segments, "README.md"],
+            })
           : null;
       return {
         kind: "dir",

--- a/src/blog/view.ts
+++ b/src/blog/view.ts
@@ -23,18 +23,13 @@ function fromTree(params: { tree: BlogTree; linkBase: string }): BlogView {
   switch (tree.kind) {
     case "file":
       return { kind: "file", text: tree.text };
-    case "dir": {
-      const entries =
-        tree.readme === null
-          ? tree.entries
-          : tree.entries.filter((entry) => entry.name !== "README.md");
+    case "dir":
       return {
         kind: "dir",
-        entries,
+        entries: tree.entries,
         linkBase,
         readme: tree.readme,
       };
-    }
   }
 }
 

--- a/src/blog/view.ts
+++ b/src/blog/view.ts
@@ -6,20 +6,34 @@ import { getBlogTree } from "./tree";
 
 export type BlogView =
   | { kind: "file"; text: string }
-  | { kind: "dir"; entries: GitContentEntry[]; linkBase: string }
+  | { kind: "dir"; entries: GitContentEntry[]; linkBase: string; readme: string | null }
   | { kind: "owner"; repos: GitRepo[] };
 
-function fromContent(params: {
+async function fromContent(params: {
   content: GitContent;
   linkBase: string;
-}): BlogView {
-  const { content, linkBase } = params;
+  owner: string;
+  repo: string;
+  segments: string[];
+}): Promise<BlogView> {
+  const { content, linkBase, owner, repo, segments } = params;
 
   switch (content.kind) {
     case "file":
       return { kind: "file", text: content.text };
-    case "dir":
-      return { kind: "dir", entries: content.entries, linkBase };
+    case "dir": {
+      const found = content.entries.find((entry) => entry.name === "README.md");
+      const file =
+        found?.type === "file"
+          ? await getGitContent({ owner, repo, segments: [...segments, "README.md"] })
+          : null;
+      return {
+        kind: "dir",
+        entries: content.entries,
+        linkBase,
+        readme: file?.kind === "file" ? file.text : null,
+      };
+    }
   }
 }
 
@@ -49,13 +63,25 @@ export async function getBlogView(params: {
 
   // If head is repo, repo wins, even if content is empty
   if (isRepo !== null) {
-    if (inRepo === null) return null;
-    return fromContent({ content: inRepo, linkBase: `/${head}` });
+    if (inRepo === null || head === undefined) return null;
+    return fromContent({
+      content: inRepo,
+      linkBase: `/${head}`,
+      owner,
+      repo: head,
+      segments: rest,
+    });
   }
 
   // If head is not repo, but profile repo found, profile wins
   if (inProfile !== null) {
-    return fromContent({ content: inProfile, linkBase: "" });
+    return fromContent({
+      content: inProfile,
+      linkBase: "",
+      owner,
+      repo: owner,
+      segments: path,
+    });
   }
 
   // Owner root without a profile repo: their repos, forks excluded

--- a/src/blog/view.ts
+++ b/src/blog/view.ts
@@ -5,14 +5,16 @@ import { getGitRepos } from "@/git/repos";
 import type { BlogTree } from "./tree";
 import { getBlogTree } from "./tree";
 
+export type BlogViewDir = {
+  kind: "dir";
+  entries: GitContentEntry[];
+  linkBase: string;
+  readme: string | null;
+};
+
 export type BlogView =
   | { kind: "file"; text: string }
-  | {
-      kind: "dir";
-      entries: GitContentEntry[];
-      linkBase: string;
-      readme: string | null;
-    }
+  | BlogViewDir
   | { kind: "owner"; repos: GitRepo[] };
 
 function fromContent(params: {

--- a/src/blog/view.ts
+++ b/src/blog/view.ts
@@ -1,7 +1,8 @@
-import type { GitContent, GitContentEntry } from "@/git/content";
+import type { GitContentEntry } from "@/git/content";
 import { getGitContent } from "@/git/content";
 import type { GitRepo } from "@/git/repos";
 import { getGitRepos } from "@/git/repos";
+import type { BlogTree } from "./tree";
 import { getBlogTree } from "./tree";
 
 export type BlogView =
@@ -14,33 +15,25 @@ export type BlogView =
     }
   | { kind: "owner"; repos: GitRepo[] };
 
-async function fromContent(params: {
-  content: GitContent;
+function fromContent(params: {
+  content: BlogTree;
   linkBase: string;
-  owner: string;
-  repo: string;
-  segments: string[];
-}): Promise<BlogView> {
-  const { content, linkBase, owner, repo, segments } = params;
+}): BlogView {
+  const { content, linkBase } = params;
 
   switch (content.kind) {
     case "file":
       return { kind: "file", text: content.text };
     case "dir": {
-      const found = content.entries.find((entry) => entry.name === "README.md");
-      const file =
-        found?.type === "file"
-          ? await getGitContent({
-              owner,
-              repo,
-              segments: [...segments, "README.md"],
-            })
-          : null;
+      const entries =
+        content.readme === null
+          ? content.entries
+          : content.entries.filter((entry) => entry.name !== "README.md");
       return {
         kind: "dir",
-        entries: content.entries,
+        entries,
         linkBase,
-        readme: file?.kind === "file" ? file.text : null,
+        readme: content.readme,
       };
     }
   }
@@ -72,25 +65,13 @@ export async function getBlogView(params: {
 
   // If head is repo, repo wins, even if content is empty
   if (isRepo !== null) {
-    if (inRepo === null || head === undefined) return null;
-    return fromContent({
-      content: inRepo,
-      linkBase: `/${head}`,
-      owner,
-      repo: head,
-      segments: rest,
-    });
+    if (inRepo === null) return null;
+    return fromContent({ content: inRepo, linkBase: `/${head}` });
   }
 
   // If head is not repo, but profile repo found, profile wins
   if (inProfile !== null) {
-    return fromContent({
-      content: inProfile,
-      linkBase: "",
-      owner,
-      repo: owner,
-      segments: path,
-    });
+    return fromContent({ content: inProfile, linkBase: "" });
   }
 
   // Owner root without a profile repo: their repos, forks excluded

--- a/src/blog/view.ts
+++ b/src/blog/view.ts
@@ -17,25 +17,22 @@ export type BlogView =
   | BlogViewDir
   | { kind: "owner"; repos: GitRepo[] };
 
-function fromContent(params: {
-  content: BlogTree;
-  linkBase: string;
-}): BlogView {
-  const { content, linkBase } = params;
+function fromTree(params: { tree: BlogTree; linkBase: string }): BlogView {
+  const { tree, linkBase } = params;
 
-  switch (content.kind) {
+  switch (tree.kind) {
     case "file":
-      return { kind: "file", text: content.text };
+      return { kind: "file", text: tree.text };
     case "dir": {
       const entries =
-        content.readme === null
-          ? content.entries
-          : content.entries.filter((entry) => entry.name !== "README.md");
+        tree.readme === null
+          ? tree.entries
+          : tree.entries.filter((entry) => entry.name !== "README.md");
       return {
         kind: "dir",
         entries,
         linkBase,
-        readme: content.readme,
+        readme: tree.readme,
       };
     }
   }
@@ -68,12 +65,12 @@ export async function getBlogView(params: {
   // If head is repo, repo wins, even if content is empty
   if (isRepo !== null) {
     if (inRepo === null) return null;
-    return fromContent({ content: inRepo, linkBase: `/${head}` });
+    return fromTree({ tree: inRepo, linkBase: `/${head}` });
   }
 
   // If head is not repo, but profile repo found, profile wins
   if (inProfile !== null) {
-    return fromContent({ content: inProfile, linkBase: "" });
+    return fromTree({ tree: inProfile, linkBase: "" });
   }
 
   // Owner root without a profile repo: their repos, forks excluded


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Folder README is an auto fetch in the tree, next to the auto `.md` suffix.

`getBlogTree` already loads a path inside one repo. It now also asks for `README.md`. If the path is a folder and that file exists, the README text rides on the dir. Mapping stays sync.

The page still only picks a view. `BlogDir` receives the README and renders it with `BlogFile`, then the entry list.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02ed6-4aa2-719d-93dc-735797e8e44a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02ed6-4aa2-719d-93dc-735797e8e44a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

