### PR TITLE
Tell users what to do after each connect result

### DIFF
--- a/src/conn/check.ts
+++ b/src/conn/check.ts
@@ -21,7 +21,7 @@ interface ResultSetup {
   verify: VercelDetailReason | null;
 }
 
-type Result =
+export type ConnCheckResult =
   | { type: "clean"; reason: ConnCleanReason }
   | { type: "custom"; reason: DomainCustomReason }
   | { type: "get"; reason: ConnGetReason }
@@ -29,9 +29,9 @@ type Result =
   | { type: "success" };
 
 export async function checkConnAction(
-  _prev: Result | undefined,
+  _prev: ConnCheckResult | undefined,
   formData: FormData,
-): Promise<Result> {
+): Promise<ConnCheckResult> {
   const raw = formData.get("domain");
   if (typeof raw !== "string") throw Error("invalid domain input");
 

--- a/src/conn/clean.ts
+++ b/src/conn/clean.ts
@@ -1,6 +1,6 @@
 import { hasDomainPlatform } from "@/domain/platform";
 
-export type ConnCleanReason = "parse" | "platform";
+export type ConnCleanReason = "parse" | "unsafe";
 
 type Result =
   | { ok: true; domain: string }
@@ -13,7 +13,7 @@ export function cleanConn(raw: string): Result {
   const domain = URL.parse(input)?.hostname ?? null;
 
   if (domain === null) return { ok: false, reason: "parse" };
-  if (hasDomainPlatform(domain)) return { ok: false, reason: "platform" };
+  if (hasDomainPlatform(domain)) return { ok: false, reason: "unsafe" };
 
   return { ok: true, domain };
 }

--- a/src/conn/form.tsx
+++ b/src/conn/form.tsx
@@ -3,6 +3,7 @@
 import type { ReactElement } from "react";
 import { useActionState } from "react";
 import { checkConnAction } from "./check";
+import { ConnInstruction } from "./instruction";
 
 export function ConnForm(): ReactElement {
   const state = useActionState(checkConnAction, undefined);
@@ -17,7 +18,7 @@ export function ConnForm(): ReactElement {
       <button type="submit" disabled={pending}>
         Connect
       </button>
-      <pre>{JSON.stringify(result)}</pre>
+      {result && <ConnInstruction result={result} />}
     </form>
   );
 }

--- a/src/conn/get.ts
+++ b/src/conn/get.ts
@@ -4,7 +4,7 @@ import { refreshVercelDomain } from "@/vercel/refresh";
 import { addConn, ConnAddReason } from "./add";
 
 // Add is the only dependency of Get now
-export type ConnGetReason = ConnAddReason
+export type ConnGetReason = ConnAddReason;
 
 type Result =
   | { ok: true; detail: VercelDetail }

--- a/src/conn/instruction.tsx
+++ b/src/conn/instruction.tsx
@@ -1,0 +1,65 @@
+import type { ReactElement } from "react";
+import type { ConnCheckResult } from "./check";
+
+export function ConnInstruction(props: {
+  result: ConnCheckResult;
+}): ReactElement {
+  const { result } = props;
+
+  switch (result.type) {
+    case "success":
+      return <p>This domain is connected.</p>;
+    case "clean":
+      switch (result.reason) {
+        case "parse":
+          return <p>Enter a domain like example.com.</p>;
+        case "unsafe":
+          return <p>That domain is not supported.</p>;
+      }
+    case "custom":
+      switch (result.reason) {
+        case "missing":
+          return (
+            <p>
+              Add a TXT record at <code>_memos</code>. Set it to your GitHub
+              path, for example <code>thien-do</code> or{" "}
+              <code>thien-do/blog/notes</code>. Then connect again.
+            </p>
+          );
+        case "unsafe":
+          return (
+            <p>
+              The TXT at <code>_memos</code> is not a valid GitHub path.
+            </p>
+          );
+      }
+    case "get":
+      return <p>This domain already has three names here.</p>;
+    case "setup": {
+      const { config, verify } = result;
+      return (
+        <>
+          {config !== null && (
+            <>
+              <p>Point this domain at us, then connect again.</p>
+              <p>
+                {config.kind === "cname" ? "CNAME" : "A"} {config.name}{" "}
+                {config.value}
+              </p>
+            </>
+          )}
+          {verify !== null && (
+            <>
+              <p>Prove you own this domain, then connect again.</p>
+              {verify.map((item) => (
+                <p key={item.value}>
+                  {item.type} {item.domain} {item.value}
+                </p>
+              ))}
+            </>
+          )}
+        </>
+      );
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
No. This branch started from #52. #53 had already landed on main and moved connect from `src/home` to `src/conn`. That is the conflict.

This PR is now on current main. The form shows the next step for each check result:

- **success** — the domain is connected
- **clean / parse** — enter a domain like example.com
- **clean / unsafe** — that domain is not supported (memos.pub and localhost)
- **custom / missing** — add a `_memos` TXT with the GitHub path
- **custom / unsafe** — that TXT is not a valid GitHub path
- **get** — three names already on this apex
- **setup** — routing record and ownership TXT together

Landing stays an input and a button. The instruction appears after Connect, not as a preface.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02ed8-bec0-7d81-898d-e4f8f9f35192?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02ed8-bec0-7d81-898d-e4f8f9f35192&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

