### PR TITLE
Use owner avatar, constrain images, and title from heading

### DIFF
--- a/src/app/blog/[owner]/[[...path]]/page.tsx
+++ b/src/app/blog/[owner]/[[...path]]/page.tsx
@@ -1,7 +1,14 @@
+import type { Metadata } from "next";
 import type { ReactElement } from "react";
+import { getBlogMeta } from "@/blog/meta";
 import { BlogPage } from "@/blog/page";
 
 type Props = PageProps<"/blog/[owner]/[[...path]]">;
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const { owner, path } = await props.params;
+  return getBlogMeta({ owner, path: path ?? [] });
+}
 
 export default async function Page(props: Props): Promise<ReactElement> {
   const { owner, path } = await props.params;

--- a/src/blog/meta.ts
+++ b/src/blog/meta.ts
@@ -35,7 +35,7 @@ export async function getBlogMeta(params: {
   path: string[];
 }): Promise<Metadata> {
   const { owner, path } = params;
-  const icon = `https://github.com/${encodeURIComponent(owner)}.png`;
+  const icon = `https://avatars.githubusercontent.com/${encodeURIComponent(owner)}`;
   const view = await getBlogView({ owner, path });
 
   if (view === null) return { icons: { icon }, title: owner };

--- a/src/blog/meta.ts
+++ b/src/blog/meta.ts
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+import { getMarkTitle } from "@/mark/title";
+import { getBlogView, type BlogView } from "./view";
+
+function dropFileExt(name: string): string {
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0) return name;
+  return name.slice(0, dot);
+}
+
+function getViewText(view: BlogView): string | null {
+  switch (view.kind) {
+    case "file":
+      return view.text;
+    case "dir":
+      return view.readme;
+    case "owner":
+      return null;
+  }
+}
+
+function getNameTitle(params: {
+  kind: BlogView["kind"];
+  owner: string;
+  path: string[];
+}): string {
+  const last = params.path.at(-1);
+  if (last === undefined) return params.owner;
+  if (params.kind === "file") return dropFileExt(last);
+  return last;
+}
+
+export async function getBlogMeta(params: {
+  owner: string;
+  path: string[];
+}): Promise<Metadata> {
+  const { owner, path } = params;
+  const icon = `https://github.com/${encodeURIComponent(owner)}.png`;
+  const view = await getBlogView({ owner, path });
+
+  if (view === null) return { icons: { icon }, title: owner };
+
+  const name = getNameTitle({ kind: view.kind, owner, path });
+  const text = getViewText(view);
+  const title = (text === null ? null : getMarkTitle(text)) ?? name;
+
+  return { icons: { icon }, title };
+}

--- a/src/blog/view.ts
+++ b/src/blog/view.ts
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import type { GitContentEntry } from "@/git/content";
 import { getGitContent } from "@/git/content";
 import type { GitRepo } from "@/git/repos";
@@ -33,7 +34,7 @@ function fromTree(params: { tree: BlogTree; linkBase: string }): BlogView {
   }
 }
 
-export async function getBlogView(params: {
+async function loadBlogView(params: {
   owner: string;
   path: string[];
 }): Promise<BlogView | null> {
@@ -74,4 +75,16 @@ export async function getBlogView(params: {
   }
 
   return null;
+}
+
+const loadBlogViewCached = cache((owner: string, pathKey: string) => {
+  const path = pathKey === "" ? [] : pathKey.split("/");
+  return loadBlogView({ owner, path });
+});
+
+export function getBlogView(params: {
+  owner: string;
+  path: string[];
+}): Promise<BlogView | null> {
+  return loadBlogViewCached(params.owner, params.path.join("/"));
 }

--- a/src/mark/title.ts
+++ b/src/mark/title.ts
@@ -1,0 +1,15 @@
+/**
+ * First ATX heading in markdown.
+ * Setext and HTML headings are skipped.
+ */
+export function getMarkTitle(text: string): string | null {
+  for (const line of text.split("\n")) {
+    const match = /^#{1,6}\s+(.*)$/.exec(line);
+    const raw = match
+      ?.at(1)
+      ?.trim()
+      .replace(/\s+#+$/, "");
+    if (raw !== undefined && raw !== "") return raw;
+  }
+  return null;
+}

--- a/src/root/global.css
+++ b/src/root/global.css
@@ -48,6 +48,11 @@ h1 {
     color: var(--slate-12);
 }
 
+img {
+    max-width: 100%;
+    height: auto;
+}
+
 strong,
 b {
     font-weight: 500;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Blog pages now take their favicon, image size, and tab title from the published repo.

**Favicon.** The tab icon is the GitHub profile photo of the repo owner, from `https://avatars.githubusercontent.com/{owner}`.

**Images.** Markdown images use `max-width: 100%` so they stay inside the reading column.

**Title.** `generateMetadata` sets the document title to the first ATX heading in the file or folder README. Setext and HTML headings are skipped. If there is no heading, the title is the repo name, folder name, or file name without extension.

Home (`memos.pub`) still uses the existing site title.

The blog view is cached per request so the page and its metadata share one GitHub load.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07163-17ce-70b5-9359-1d8ce509bf52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07163-17ce-70b5-9359-1d8ce509bf52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

