### PR TITLE
Use relative blog links with directory slashes

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,10 @@
+import type { NextConfig } from "next";
+
+const config: NextConfig = {
+  // This is super important.
+  // We rely on the original behaviour for relative links.
+  // Directories must always end in a trailing slash, files must never.
+  skipTrailingSlashRedirect: true,
+};
+
+export default config;

--- a/src/blog/dir.tsx
+++ b/src/blog/dir.tsx
@@ -1,21 +1,30 @@
 import type { ReactElement } from "react";
 import { MarkFile } from "@/mark/file";
-import type { BlogViewDir } from "./view";
+import { GitContentEntry } from "@/git/content";
+import { BlogTreeDir } from "./tree";
 
-export function BlogDir(props: { view: BlogViewDir }): ReactElement {
-  const { view } = props;
-  const { linkBase, entries, readme } = view;
+function Row(props: { entry: GitContentEntry }): ReactElement {
+  const { entry } = props;
+
+  const name = entry.type === "dir" ? `${entry.name}/` : entry.name;
+
+  return (
+    <li>
+      <a href={`./${name}`}>{name}</a>
+    </li>
+  );
+}
+
+export function BlogDir(props: { dir: BlogTreeDir }): ReactElement {
+  const { dir } = props;
+  const { readme, entries } = dir;
 
   return (
     <div>
       {readme !== null ? <MarkFile text={readme} /> : null}
       <ul>
         {entries.map((entry) => (
-          <li key={entry.path}>
-            <a href={`${linkBase}/${entry.path}`}>
-              {entry.type === "dir" ? `${entry.name}/` : entry.name}
-            </a>
-          </li>
+          <Row key={entry.name} entry={entry} />
         ))}
       </ul>
     </div>

--- a/src/blog/owner.tsx
+++ b/src/blog/owner.tsx
@@ -8,7 +8,7 @@ export function BlogOwner(props: { repos: GitRepo[] }): ReactElement {
     <ul>
       {repos.map((repo) => (
         <li key={repo.name}>
-          <a href={`/${repo.name}`}>{repo.name}</a>
+          <a href={`./${repo.name}/`}>{repo.name}</a>
         </li>
       ))}
     </ul>

--- a/src/blog/page.tsx
+++ b/src/blog/page.tsx
@@ -1,8 +1,9 @@
-import type { ReactElement } from "react";
-import { notFound } from "next/navigation";
 import { MarkFile } from "@/mark/file";
+import { notFound } from "next/navigation";
+import type { ReactElement } from "react";
 import { BlogDir } from "./dir";
 import { BlogOwner } from "./owner";
+import { ensureBlogSlash } from "./slash";
 import { getBlogView } from "./view";
 
 export async function BlogPage(props: {
@@ -14,11 +15,13 @@ export async function BlogPage(props: {
   const view = await getBlogView({ owner, path });
   if (view === null) notFound();
 
+  await ensureBlogSlash(view);
+
   switch (view.kind) {
     case "file":
       return <MarkFile text={view.text} />;
     case "dir":
-      return <BlogDir view={view} />;
+      return <BlogDir dir={view} />;
     case "owner":
       return <BlogOwner repos={view.repos} />;
   }

--- a/src/blog/slash.ts
+++ b/src/blog/slash.ts
@@ -1,0 +1,28 @@
+import { BlogView } from "./view";
+import { headers as getHeaders } from "next/headers";
+import { notFound, redirect } from "next/navigation";
+
+/**
+ * Our links are always relative,
+ * so they require strict trailing slash behaviour.
+ */
+export async function ensureBlogSlash(view: BlogView): Promise<void> {
+  const headers = await getHeaders();
+  // Provided by our proxy
+  const pathname = headers.get("x-memos-pathname");
+  if (pathname === null) throw new Error("Missing pathname header");
+
+  const hasSlash = pathname.endsWith("/");
+
+  switch (view.kind) {
+    case "file":
+      // We don't support custom domain to specific files.
+      if (pathname === "/") notFound();
+      if (hasSlash) redirect(pathname.slice(0, -1));
+      return;
+    case "dir":
+    case "owner":
+      if (!hasSlash) redirect(`${pathname}/`);
+      return;
+  }
+}

--- a/src/blog/tree.ts
+++ b/src/blog/tree.ts
@@ -1,13 +1,18 @@
 import type { GitContentEntry } from "@/git/content";
 import { getGitContent } from "@/git/content";
 
-export type BlogTree =
-  | { kind: "file"; text: string }
-  | {
-      kind: "dir";
-      entries: GitContentEntry[];
-      readme: string | null;
-    };
+export interface BlogTreeFile {
+  kind: "file";
+  text: string;
+}
+
+export interface BlogTreeDir {
+  kind: "dir";
+  entries: GitContentEntry[];
+  readme: string | null;
+}
+
+export type BlogTree = BlogTreeFile | BlogTreeDir;
 
 /**
  * Get content within a specific repo.

--- a/src/blog/view.ts
+++ b/src/blog/view.ts
@@ -1,37 +1,15 @@
-import type { GitContentEntry } from "@/git/content";
 import { getGitContent } from "@/git/content";
 import type { GitRepo } from "@/git/repos";
 import { getGitRepos } from "@/git/repos";
 import type { BlogTree } from "./tree";
 import { getBlogTree } from "./tree";
 
-export type BlogViewDir = {
-  kind: "dir";
-  entries: GitContentEntry[];
-  linkBase: string;
-  readme: string | null;
-};
-
-export type BlogView =
-  | { kind: "file"; text: string }
-  | BlogViewDir
-  | { kind: "owner"; repos: GitRepo[] };
-
-function fromTree(params: { tree: BlogTree; linkBase: string }): BlogView {
-  const { tree, linkBase } = params;
-
-  switch (tree.kind) {
-    case "file":
-      return { kind: "file", text: tree.text };
-    case "dir":
-      return {
-        kind: "dir",
-        entries: tree.entries,
-        linkBase,
-        readme: tree.readme,
-      };
-  }
+interface Owner {
+  kind: "owner";
+  repos: GitRepo[];
 }
+
+export type BlogView = BlogTree | Owner;
 
 export async function getBlogView(params: {
   owner: string;
@@ -58,15 +36,10 @@ export async function getBlogView(params: {
   ]);
 
   // If head is repo, repo wins, even if content is empty
-  if (isRepo !== null) {
-    if (inRepo === null) return null;
-    return fromTree({ tree: inRepo, linkBase: `/${head}` });
-  }
+  if (isRepo !== null) return inRepo;
 
   // If head is not repo, but profile repo found, profile wins
-  if (inProfile !== null) {
-    return fromTree({ tree: inProfile, linkBase: "" });
-  }
+  if (inProfile !== null) return inProfile;
 
   // Owner root without a profile repo: their repos, forks excluded
   if (repos !== null) {

--- a/src/host/blog.ts
+++ b/src/host/blog.ts
@@ -1,11 +1,18 @@
+import { NextRequest } from "next/server";
 import { getHostCustomPath } from "./custom";
 import { getHostPlatformOwner, getIsHostPlatform } from "./platform";
 
 /**
- * Get a potential log path from a hostname,
+ * Get a potential blog path from a request,
  * covering both custom and platform.
  */
-export async function getHostBlog(hostname: string): Promise<string | null> {
+export async function getHostBlog(
+  request: NextRequest,
+): Promise<string | null> {
+  // nextUrl.hostname is not reliable, as Vercel overrides it after handled.
+  const host = request.headers.get("host") ?? "";
+  const hostname = host.split(":").at(0)?.toLowerCase() ?? "";
+
   const isPlatform = getIsHostPlatform(hostname);
   return isPlatform
     ? getHostPlatformOwner(hostname)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,26 +4,28 @@ import { getHostBlog } from "./host/blog";
 
 const IS_PREVIEW = process.env.VERCEL_ENV === "preview";
 
-function getHostname(request: NextRequest): string {
-  // nextUrl is not reliable, as Vercel may override it
-  const host = request.headers.get("host") ?? "";
-  const hostname = host.split(":").at(0)?.toLowerCase() ?? "";
-  return hostname;
+type Init = NonNullable<Parameters<typeof NextResponse.next>[0]>;
+
+/** We rely on the original pathname for trailing slash redirect */
+function addPathname(request: NextRequest): Init {
+  const headers = new Headers(request.headers);
+  const { pathname } = request.nextUrl;
+  headers.set("x-memos-pathname", pathname);
+  return { request: { headers } };
 }
 
 export async function proxy(request: NextRequest): Promise<NextResponse> {
-  // No blog routing in preview.
-  // Check this first to avoid paying host lookup cost.
-  if (IS_PREVIEW) return NextResponse.next();
+  const options = addPathname(request);
 
-  const hostname = getHostname(request);
+  // Previews use the blog route directly.
+  if (IS_PREVIEW) return NextResponse.next(options);
 
-  const blog = await getHostBlog(hostname);
+  const blog = await getHostBlog(request);
   if (typeof blog === "string") {
     const url = request.nextUrl.clone();
     const target = blog.split("/").map(encodeURIComponent).join("/");
     url.pathname = `/blog/${target}${url.pathname}`;
-    return NextResponse.rewrite(url);
+    return NextResponse.rewrite(url, options);
   }
 
   // Prevent direct access to avoid duplicated paths
@@ -31,7 +33,7 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   if (pathname === "/blog" || pathname.startsWith("/blog/"))
     return new NextResponse("Not Found", { status: 404 });
 
-  return NextResponse.next();
+  return NextResponse.next(options);
 }
 
 export const config = {


### PR DESCRIPTION
Directory links included repo paths that a custom domain already represents. Use relative links instead, with directory URLs ending in `/` and file URLs without it. This also lets nested README links resolve from the directory being displayed.

After fetching content, the page corrects the trailing slash before rendering. The proxy forwards only the original public pathname; slash redirects discard query strings. `BlogView` returns content directly, and host lookup stays in the proxy. Disable Next's automatic slash redirects so the content kind determines the URL.

Validation: TypeScript, lint, and formatting passed. Checked 16 proxy/page cases with Next's request, response, and redirect helpers, plus three rendered-link cases. These cover domain roots, directories, files, missing content, query removal, and preview routes without host lookups.
