### PR TITLE
Keep markdown images inside the reading column

### DIFF
--- a/src/root/global.css
+++ b/src/root/global.css
@@ -48,6 +48,11 @@ h1 {
     color: var(--slate-12);
 }
 
+img {
+    max-width: 100%;
+    height: auto;
+}
+
 strong,
 b {
     font-weight: 500;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Markdown images that are wider than the page now stay inside the reading column.

This sets `max-width: 100%` and `height: auto` on `img` in the global stylesheet. Small images keep their natural size.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07163-17ce-70b5-9359-1d8ce509bf52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07163-17ce-70b5-9359-1d8ce509bf52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

