### PR TITLE
Use the repo owner photo as the blog favicon

### DIFF
--- a/src/app/blog/[owner]/[[...path]]/page.tsx
+++ b/src/app/blog/[owner]/[[...path]]/page.tsx
@@ -1,7 +1,14 @@
+import type { Metadata } from "next";
 import type { ReactElement } from "react";
+import { getBlogIcon } from "@/blog/icon";
 import { BlogPage } from "@/blog/page";
 
 type Props = PageProps<"/blog/[owner]/[[...path]]">;
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const { owner } = await props.params;
+  return { icons: { icon: getBlogIcon(owner) } };
+}
 
 export default async function Page(props: Props): Promise<ReactElement> {
   const { owner, path } = await props.params;

--- a/src/blog/icon.ts
+++ b/src/blog/icon.ts
@@ -1,0 +1,3 @@
+export function getBlogIcon(owner: string): string {
+  return `https://avatars.githubusercontent.com/${encodeURIComponent(owner)}`;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Each blog uses the GitHub profile photo of the repo owner as its favicon.

`generateMetadata` points the icon at `https://avatars.githubusercontent.com/{owner}`. The home page is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07163-17ce-70b5-9359-1d8ce509bf52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07163-17ce-70b5-9359-1d8ce509bf52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

